### PR TITLE
LineCollection flexibility improvements

### DIFF
--- a/Aegisub-Motion.moon
+++ b/Aegisub-Motion.moon
@@ -221,7 +221,7 @@ prepareLines = ( lineCollection ) ->
 	options = lineCollection.options
 	-- remove the lines while ensuring new lines will be inserted in the
 	-- correct place.
-	lineCollection\deleteWithShift!
+	lineCollection\deleteLines!
 
 	-- Perform all of the manipulation that used to be performed in
 	-- Line.moon but are actually fairly Aegisub-Motion specific.

--- a/src/LineCollection.moon
+++ b/src/LineCollection.moon
@@ -196,3 +196,6 @@ class LineCollection
 			for line in *@lines
 				if line.inserted and not line.hasBeenDeleted
 					@sub[line.number] = line
+	getSelection: =>
+		sel = [line.number for line in *@lines when line.selected and line.inserted and not line.hasBeenDeleted]
+		return sel, sel[#sel]

--- a/src/LineCollection.moon
+++ b/src/LineCollection.moon
@@ -12,18 +12,22 @@ class LineCollection
 	@version_patch: bit.band( @version, 0xFF )
 	@version_string: ("%d.%d.%d")\format @version_major, @version_minor, @version_patch
 
-	new: ( @sub, sel, validationCb ) =>
+	new: ( @sub, sel, validationCb, selectLines=true ) =>
 		@lines = { }
 		if sel
-			@collectLines sel, validationCb
+			@collectLines sel, validationCb, selectLines
 			if frameFromMs 0
 				@getFrameInfo!
 
 	-- This method should update various properties such as
 	-- (start|end)(Time|Frame).
-	addLine: ( line, validationCb = () -> return true ) =>
+	addLine: ( line, validationCb = (-> return true), selectLine=true ) =>
 		if validationCb line
 			line.parentCollection = @
+			line.inserted = false
+			line.selected = selectLine
+			line.number = nil
+			frame_from_ms = aegisub.frame_from_ms
 
 			-- if @startTime is unset, @endTime should damn well be too.
 			if @startTime
@@ -70,7 +74,7 @@ class LineCollection
 
 		@hasMetaStyles = true
 
-	collectLines: ( sel, validationCb = ( line ) -> return not line.comment ) =>
+	collectLines: ( sel, validationCb = ( ( line ) -> return not line.comment), selectLines=true ) =>
 		unless @hasMetaStyles
 			@generateMetaAndStyles!
 
@@ -82,11 +86,17 @@ class LineCollection
 
 		@startTime  = @sub[sel[1]].start_time
 		@endTime    = @sub[sel[1]].end_time
+		@lastLineNumber = 0
 
 		for i = #sel, 1, -1
 			with line = Line @sub[sel[i]], @
 				if validationCb line
 					.number = sel[i]
+					@firstLineNumber = math.min .number, @firstLineNumber or .number
+					@lastLineNumber = math.max .number, @lastLineNumber
+					.inserted = true
+					.hasBeenDeleted = false
+					.selected = selectLines
 					.humanizedNumber = .number - dialogueStart
 					.styleRef = @styles[.style]
 
@@ -129,19 +139,17 @@ class LineCollection
 
 	combineIdenticalLines: =>
 		lastLine = @lines[1]
-		newLineTable = { }
+		linesToSkip = { }
 		for i = 2, #@lines
 			log.checkCancellation!
 
 			if lastLine\combineWithLine @lines[i]
+				linesToSkip[#linesToSkip+1] = @lines[i]
 				@shouldInsertLines = true
 				continue
-			else
-				table.insert newLineTable, lastLine
-				lastLine = @lines[i]
+			else lastLine = @lines[i]
+		@deleteLines linesToSkip
 
-		table.insert newLineTable, lastLine
-		@lines = newLineTable
 
 	runCallback: ( callback, reverse ) =>
 		if reverse
@@ -151,24 +159,40 @@ class LineCollection
 			for index = 1, #@lines
 				callback @, @lines[index], index
 
-	deleteLines: =>
-		for line in *@lines
-			line\delete!
+	deleteLines: ( lines=@lines, doShift=true ) =>
+		if lines.__class == Line
+			lines = { lines }
 
-	deleteWithShift: =>
-		shift = #@lines
+		lineSet = {line,true for _,line in pairs lines when not line.hasBeenDeleted}
+		-- make sure all lines are unique and have not actually been already removed
+		lines = [k for k,v in pairs lineSet]
+
+		@sub.delete [line.number for line in *lines when line.inserted]
+
+		@lastLineNumber = @firstLineNumber-1
+		shift = #lines or 0
 		for line in *@lines
-			line\delete!
-			line.number -= shift
-			shift -= 1
+			if lineSet[line]
+				line.hasBeenDeleted = true
+				line.number = nil
+				shift -= line.inserted and 1 or 0
+			elseif not line.hasBeenDeleted and line.inserted
+				line.number -= doShift and shift or 0
+				@lastLineNumber = math.max(line.number, @lastLineNumber)
 
 	insertLines: =>
-		for line in *@lines
-			@sub.insert line.number + 1, line
+		inserted = [line for line in *@lines when not (line.inserted or line.hasBeenDeleted)]
+		for i=#inserted, 1, -1
+			line = inserted[i]
+			line.number = @lastLineNumber + #inserted - i + 1
+			@sub.insert line.number, line
+			line.inserted = true
+		@lastLineNumber = @lastLineNumber + #inserted
 
 	replaceLines: =>
 		if @shouldInsertLines
 			@insertLines!
 		else
 			for line in *@lines
-				@sub[line.number] = line
+				if line.inserted and not line.hasBeenDeleted
+					@sub[line.number] = line

--- a/src/MotionHandler.moon
+++ b/src/MotionHandler.moon
@@ -61,6 +61,7 @@ class MotionHandler
 		@resultingCollection = LineCollection @lineCollection.sub
 		@resultingCollection.shouldInsertLines = true
 		@resultingCollection.options = @options
+		@resultingCollection.firstLineNumber = @lineCollection.firstLineNumber
 		-- This has to be copied over for clip interpolation
 		@resultingCollection.meta = @lineCollection.meta
 		for line in *@lineCollection.lines


### PR DESCRIPTION
This patch enables LineCollections to do partial deletion and insertion of lines from/into the subtitle object, while keeping the collection and line numbers in sync with the applied changes. This hopefully allows users to keep using the same LineCollection after running deleteLines() or insertLines() without having to worry about the line numbers being off, duplicate insertions/deletions, etc. 
Also included is a new getSelection() method, which benefits from the consistent line numbers and can be used to return a new selection and active line from an Aegisub macro. 