### PR TITLE
LineCollection improvements, part 2

### DIFF
--- a/src/LineCollection.moon
+++ b/src/LineCollection.moon
@@ -14,10 +14,16 @@ class LineCollection
 
 	new: ( @sub, sel, validationCb, selectLines=true ) =>
 		@lines = { }
-		if sel
+		if sel and #sel>0
 			@collectLines sel, validationCb, selectLines
 			if frameFromMs 0
 				@getFrameInfo!
+		else
+			for i=#@sub,1,-1 do
+				if @sub[i].class == "dialogue" then
+					@lastLineNumber = i
+					@firstLineNumber = i
+					break
 
 	-- This method should update various properties such as
 	-- (start|end)(Time|Frame).

--- a/src/LineCollection.moon
+++ b/src/LineCollection.moon
@@ -187,21 +187,27 @@ class LineCollection
 
 	insertLines: =>
 		toInsert = [line for line in *@lines when not (line.inserted or line.hasBeenDeleted)]
-		tailLines = [line for line in *toInsert when not line.number]
-		numberedLines = [line for line in *toInsert when line.number]
+		tailLines, numberedLines = {}, {}
 
-		for i=1,#tailLines
-			tailLines[i].number = @lastLineNumber + i
-			tailLines[i].inserted = true
+		for i=1,#toInsert
+			line = toInsert[i]
+			if line.number
+				numberedLines[#numberedLines+1] = line
+				line.i = i
+			else
+				tailLines[#tailLines+1] = line
+				line.number = @lastLineNumber + i
+				line.inserted = true
 
-		table.sort numberedLines, (a,b) -> return a.number < b.number
+		table.sort numberedLines, (a,b) ->
+			return a.number < b.number or a.number==b.number and a.i < b.i
 		for line in *numberedLines
 			@sub.insert line.number, line
 			line.inserted = true
 			@lastLineNumber = math.max @lastLineNumber, line.number
 
 		unless #tailLines==0
-			@sub.insert @lastLineNumber +1, unpack tailLines
+			@sub.insert @lastLineNumber+1, unpack tailLines
 			@lastLineNumber = math.max @lastLineNumber, tailLines[#tailLines].number
 
 	replaceLines: =>

--- a/src/MotionHandler.moon
+++ b/src/MotionHandler.moon
@@ -118,7 +118,7 @@ class MotionHandler
 				.text = .text\gsub "\\pos(%b())\\t%((%d+,%d+),\\pos(%b())%)", ( start, time, finish ) ->
 					"\\move" .. start\sub( 1, -2 ) .. ',' .. finish\sub( 2, -2 ) .. ',' .. time .. ")"
 
-			@resultingCollection\addLine (Line line, nil, { wasLinear: true }), nil, true, true
+			@resultingCollection\addLine Line( line, nil, { wasLinear: true } ), nil, true, true
 
 	nonlinear = ( line ) =>
 		for frame = line.relativeEnd, line.relativeStart, -1
@@ -156,7 +156,7 @@ class MotionHandler
 					newText = newText\gsub pattern, ( tag, value ) ->
 						tag .. callback @, value, frame
 
-				@resultingCollection\addLine (Line line, @resultingCollection, { text: newText, start_time: newStartTime, end_time: newEndTime, transformShift: timeDelta }),
+				@resultingCollection\addLine Line( line, @resultingCollection, { text: newText, start_time: newStartTime, end_time: newEndTime, transformShift: timeDelta } ),
 											 nil, true, true
 
 	position = ( pos, frame ) =>

--- a/src/MotionHandler.moon
+++ b/src/MotionHandler.moon
@@ -61,7 +61,6 @@ class MotionHandler
 		@resultingCollection = LineCollection @lineCollection.sub
 		@resultingCollection.shouldInsertLines = true
 		@resultingCollection.options = @options
-		@resultingCollection.firstLineNumber = @lineCollection.firstLineNumber
 		-- This has to be copied over for clip interpolation
 		@resultingCollection.meta = @lineCollection.meta
 		for line in *@lineCollection.lines

--- a/src/MotionHandler.moon
+++ b/src/MotionHandler.moon
@@ -77,6 +77,7 @@ class MotionHandler
 		totalLines = #@lineCollection.lines
 		-- The lines are collected in reverse order in LineCollection so
 		-- that we don't need to do things in reverse here.
+		insertNumber = @lineCollection.lines[totalLines].number
 		for index = 1, totalLines
 			with line = @lineCollection.lines[index]
 
@@ -84,7 +85,7 @@ class MotionHandler
 				.relativeStart = .startFrame - @lineCollection.startFrame + 1
 				-- end frame of line relative to start frame of tracked data
 				.relativeEnd = .endFrame - @lineCollection.startFrame
-
+				.number = insertNumber
 				.method @, line
 
 			setProgress index/totalLines
@@ -118,7 +119,7 @@ class MotionHandler
 				.text = .text\gsub "\\pos(%b())\\t%((%d+,%d+),\\pos(%b())%)", ( start, time, finish ) ->
 					"\\move" .. start\sub( 1, -2 ) .. ',' .. finish\sub( 2, -2 ) .. ',' .. time .. ")"
 
-			@resultingCollection\addLine Line line, nil, { wasLinear: true }
+			@resultingCollection\addLine (Line line, nil, { wasLinear: true }), nil, true, true
 
 	nonlinear = ( line ) =>
 		for frame = line.relativeEnd, line.relativeStart, -1
@@ -156,7 +157,8 @@ class MotionHandler
 					newText = newText\gsub pattern, ( tag, value ) ->
 						tag .. callback @, value, frame
 
-				@resultingCollection\addLine Line line, @resultingCollection, { text: newText, start_time: newStartTime, end_time: newEndTime, transformShift: timeDelta }
+				@resultingCollection\addLine (Line line, @resultingCollection, { text: newText, start_time: newStartTime, end_time: newEndTime, transformShift: timeDelta }),
+											 nil, true, true
 
 	position = ( pos, frame ) =>
 		x, y = pos\match "([%-%d%.]+),([%-%d%.]+)"


### PR DESCRIPTION
This patch adds further improvements and corrections to the LineCollection module:
* Inserting lines at arbitrary indexes (rather than only at the end of the selection) is now once again possible through a parameter to :addLines(). Indexed and unnumbered (tail) can be mixed without issues.
* Tail lines are now inserted in the order they were added to the collection (was reverse order before)
* Inserting tail lines from a collection created without a selection no longer results in an error. The lines will be added below the last dialogue line in the file.